### PR TITLE
Wait output gets copied in clipboard (Linux)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use std::env;
-
+use std::{thread, time};
 use clipboard::{ClipboardContext, ClipboardProvider};
 
 fn main() {
@@ -25,4 +25,5 @@ fn main() {
     let mut ctx: ClipboardContext = ClipboardProvider::new().unwrap();
 
     ctx.set_contents(output).unwrap(); // Copy the header to clipboard.
+    thread::sleep(time::Duration::from_secs(1)); // This is for Linux users.
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,5 +25,5 @@ fn main() {
     let mut ctx: ClipboardContext = ClipboardProvider::new().unwrap();
 
     ctx.set_contents(output).unwrap(); // Copy the header to clipboard.
-    thread::sleep(time::Duration::from_secs(1)); // This is for Linux users.
+    thread::sleep(time::Duration::from_millis(100)); // This is for Linux users.
 }


### PR DESCRIPTION
Without that new line, i didn't get the output copied in my clipboard (I'm using Ubuntu 22.04)