### PR TITLE
📝 Suggest empty "problemMatcher"

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Set your global [`tasks.json`](https://stackoverflow.com/questions/41046494/maki
       "command": "headers ${input:header}",
       "presentation": {
         "reveal": "never"
-      }
+      },
+      "problemMatcher": []
     }
   ],
   "inputs": [


### PR DESCRIPTION
Adding the `problemsMatcher` option in the VSCode task configuration makes it so that this prompt is no longer showed to the user:

> Select for which kind of errors or warnings to scan the output

For more detail on the rationale of doing this, see this [post](https://stackoverflow.com/q/71675367/3873510) on StackOverflow.