### PR TITLE
Add clone command in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ You need Rust and Cargo installed on your machine. See the installation guide
 Then clone the repo and install the CLI globally like this:
 
 ```sh
+git clone https://github.com/transmissions11/headers.git
+cd headers
 cargo install --path .
 ```
 


### PR DESCRIPTION
It might be a bit of an overkill, but adding

```sh
git clone https://github.com/transmissions11/headers.git
cd headers
```

could make it simpler for beginner or intermediate developers to get started quickly.